### PR TITLE
feat(appmesh): add timeout support to Routes

### DIFF
--- a/packages/@aws-cdk/aws-appmesh/README.md
+++ b/packages/@aws-cdk/aws-appmesh/README.md
@@ -282,7 +282,7 @@ The _RouteSpec_ class provides an easy interface for defining new protocol speci
 The `tcp()`, `http()` and `http2()` methods provide the spec necessary to define a protocol specific spec.
 
 For HTTP based routes, the match field can be used to match on a route prefix.
-By default, an HTTP based route will match on `/`. All matches must start with a leading `/`.
+By default, an HTTP based route will match on `/`. All matches must start with a leading `/`. The timeout field can also be specified for `idle` and `perRequest` timeouts.
 
 ```ts
 router.addRoute('route-http', {
@@ -294,6 +294,10 @@ router.addRoute('route-http', {
     ],
     match: {
       serviceName: 'my-service.default.svc.cluster.local',
+    },
+    timeout:  {
+      idle : Duration.seconds(2),
+      perRequest: Duration.seconds(1),
     },
   }),
 });

--- a/packages/@aws-cdk/aws-appmesh/lib/route-spec.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/route-spec.ts
@@ -61,6 +61,7 @@ export interface HttpRouteSpecOptions {
 
   /**
    * An object that represents a http timeout
+   *
    * @default - None
    */
   readonly timeout?: HttpTimeout;
@@ -77,6 +78,7 @@ export interface TcpRouteSpecOptions {
 
   /**
    * An object that represents a tcp timeout
+   *
    * @default - None
    */
   readonly timeout?: TcpTimeout;
@@ -93,6 +95,7 @@ export interface GrpcRouteSpecOptions {
 
   /**
    * An object that represents a grpc timeout
+   *
    * @default - None
    */
   readonly timeout?: GrpcTimeout;
@@ -184,6 +187,7 @@ class HttpRouteSpec extends RouteSpec {
 
   /**
    * The criteria for determining a request match
+   *
    */
   public readonly match?: HttpRouteMatch;
 
@@ -226,7 +230,7 @@ class HttpRouteSpec extends RouteSpec {
   }
 
   private renderTimeout(timeout: HttpTimeout): CfnRoute.HttpTimeoutProperty {
-    return ({
+    return {
       idle: timeout?.idle !== undefined ? {
         unit: 'ms',
         value: timeout?.idle.toMilliseconds(),
@@ -235,7 +239,7 @@ class HttpRouteSpec extends RouteSpec {
         unit: 'ms',
         value: timeout?.perRequest.toMilliseconds(),
       } : undefined,
-    });
+    };
   }
 }
 

--- a/packages/@aws-cdk/aws-appmesh/lib/shared-interfaces.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/shared-interfaces.ts
@@ -2,6 +2,56 @@ import * as cdk from '@aws-cdk/core';
 import { CfnVirtualGateway, CfnVirtualNode } from './appmesh.generated';
 
 /**
+ * Represents timeouts for HTTP protocols.
+ */
+export interface HttpTimeout {
+  /**
+   * Represents an idle timeout. The amount of time that a connection may be idle.
+   *
+   * @default - none
+   */
+  readonly idle?: cdk.Duration;
+
+  /**
+   * Represents per request timeout.
+   *
+   * @default - 15 s
+   */
+  readonly perRequest?: cdk.Duration;
+}
+
+/**
+ * Represents timeouts for GRPC protocols.
+ */
+export interface GrpcTimeout {
+  /**
+   * Represents an idle timeout. The amount of time that a connection may be idle.
+   *
+   * @default - none
+   */
+  readonly idle?: cdk.Duration;
+
+  /**
+   * Represents per request timeout.
+   *
+   * @default - 15 s
+   */
+  readonly perRequest?: cdk.Duration;
+}
+
+/**
+ * Represents timeouts for TCP protocols.
+ */
+export interface TcpTimeout {
+  /**
+   * Represents an idle timeout. The amount of time that a connection may be idle.
+   *
+   * @default - none
+   */
+  readonly idle?: cdk.Duration;
+}
+
+/**
  * Enum of supported AppMesh protocols
  */
 export enum Protocol {

--- a/packages/@aws-cdk/aws-appmesh/lib/virtual-node-listener.ts
+++ b/packages/@aws-cdk/aws-appmesh/lib/virtual-node-listener.ts
@@ -1,7 +1,7 @@
 import * as cdk from '@aws-cdk/core';
 import { CfnVirtualNode } from './appmesh.generated';
 import { validateHealthChecks } from './private/utils';
-import { HealthCheck, Protocol } from './shared-interfaces';
+import { HealthCheck, Protocol, HttpTimeout, GrpcTimeout, TcpTimeout } from './shared-interfaces';
 
 /**
  * Properties for a VirtualNode listener
@@ -66,56 +66,6 @@ export interface TcpVirtualNodeListenerOptions extends VirtualNodeListenerCommon
    * @default - None
    */
   readonly timeout?: TcpTimeout;
-}
-
-/**
- * Represents timeouts for HTTP protocols.
- */
-export interface HttpTimeout {
-  /**
-   * Represents an idle timeout. The amount of time that a connection may be idle.
-   *
-   * @default - none
-   */
-  readonly idle?: cdk.Duration;
-
-  /**
-   * Represents per request timeout.
-   *
-   * @default - 15 s
-   */
-  readonly perRequest?: cdk.Duration;
-}
-
-/**
- * Represents timeouts for GRPC protocols.
- */
-export interface GrpcTimeout {
-  /**
-   * Represents an idle timeout. The amount of time that a connection may be idle.
-   *
-   * @default - none
-   */
-  readonly idle?: cdk.Duration;
-
-  /**
-   * Represents per request timeout.
-   *
-   * @default - 15 s
-   */
-  readonly perRequest?: cdk.Duration;
-}
-
-/**
- * Represents timeouts for TCP protocols.
- */
-export interface TcpTimeout {
-  /**
-   * Represents an idle timeout. The amount of time that a connection may be idle.
-   *
-   * @default - none
-   */
-  readonly idle?: cdk.Duration;
 }
 
 /**

--- a/packages/@aws-cdk/aws-appmesh/package.json
+++ b/packages/@aws-cdk/aws-appmesh/package.json
@@ -180,7 +180,10 @@
       "duration-prop-type:@aws-cdk/aws-appmesh.GrpcVirtualNodeListenerOptions.timeout",
       "duration-prop-type:@aws-cdk/aws-appmesh.HttpVirtualNodeListenerOptions.timeout",
       "duration-prop-type:@aws-cdk/aws-appmesh.Http2VirtualNodeListenerOptions.timeout",
-      "duration-prop-type:@aws-cdk/aws-appmesh.TcpVirtualNodeListenerOptions.timeout"
+      "duration-prop-type:@aws-cdk/aws-appmesh.TcpVirtualNodeListenerOptions.timeout",
+      "duration-prop-type:@aws-cdk/aws-appmesh.GrpcRouteSpecOptions.timeout",
+      "duration-prop-type:@aws-cdk/aws-appmesh.HttpRouteSpecOptions.timeout",
+      "duration-prop-type:@aws-cdk/aws-appmesh.TcpRouteSpecOptions.timeout"
     ]
   },
   "stability": "experimental",

--- a/packages/@aws-cdk/aws-appmesh/test/integ.mesh.expected.json
+++ b/packages/@aws-cdk/aws-appmesh/test/integ.mesh.expected.json
@@ -515,6 +515,16 @@
             },
             "Match": {
               "Prefix": "/"
+            },
+            "Timeout": {
+              "Idle": {
+                "Unit": "ms",
+                "Value": 10000
+              },
+              "PerRequest": {
+                "Unit": "ms",
+                "Value": 10000
+              }
             }
           }
         },
@@ -553,6 +563,16 @@
             },
             "Match": {
               "Prefix": "/path2"
+            },
+            "Timeout": {
+              "Idle": {
+                "Unit": "ms",
+                "Value": 11000
+              },
+              "PerRequest": {
+                "Unit": "ms",
+                "Value": 11000
+              }
             }
           }
         },
@@ -588,6 +608,12 @@
                   "Weight": 20
                 }
               ]
+            },
+            "Timeout": {
+              "Idle": {
+                "Unit": "ms",
+                "Value": 12000
+              }
             }
           }
         },

--- a/packages/@aws-cdk/aws-appmesh/test/integ.mesh.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/integ.mesh.ts
@@ -59,6 +59,10 @@ router.addRoute('route-1', {
     match: {
       prefixPath: '/',
     },
+    timeout: {
+      idle: cdk.Duration.seconds(10),
+      perRequest: cdk.Duration.seconds(10),
+    },
   }),
 });
 
@@ -118,6 +122,10 @@ router.addRoute('route-2', {
     match: {
       prefixPath: '/path2',
     },
+    timeout: {
+      idle: cdk.Duration.seconds(11),
+      perRequest: cdk.Duration.seconds(11),
+    },
   }),
 });
 
@@ -129,6 +137,9 @@ router.addRoute('route-3', {
         weight: 20,
       },
     ],
+    timeout: {
+      idle: cdk.Duration.seconds(12),
+    },
   }),
 });
 

--- a/packages/@aws-cdk/aws-appmesh/test/test.route.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.route.ts
@@ -29,6 +29,10 @@ export = {
               virtualNode: node,
             },
           ],
+          timeout: {
+            idle: cdk.Duration.seconds(10),
+            perRequest: cdk.Duration.seconds(10),
+          },
         }),
       });
 
@@ -39,6 +43,10 @@ export = {
               virtualNode: node,
             },
           ],
+          timeout: {
+            idle: cdk.Duration.seconds(10),
+            perRequest: cdk.Duration.seconds(10),
+          },
         }),
       });
 
@@ -49,6 +57,9 @@ export = {
               virtualNode: node,
             },
           ],
+          timeout: {
+            idle: cdk.Duration.seconds(10),
+          },
         }),
       });
 
@@ -61,6 +72,10 @@ export = {
           ],
           match: {
             serviceName: 'test.svc.local',
+          },
+          timeout: {
+            idle: cdk.Duration.seconds(10),
+            perRequest: cdk.Duration.seconds(10),
           },
         }),
       });
@@ -187,6 +202,10 @@ export = {
           ],
           match: {
             prefixPath: '/node',
+          },
+          timeout: {
+            idle: cdk.Duration.seconds(10),
+            perRequest: cdk.Duration.seconds(10),
           },
         }),
       });

--- a/packages/@aws-cdk/aws-appmesh/test/test.route.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.route.ts
@@ -31,7 +31,7 @@ export = {
           ],
           timeout: {
             idle: cdk.Duration.seconds(10),
-            perRequest: cdk.Duration.seconds(10),
+            perRequest: cdk.Duration.seconds(11),
           },
         }),
       });
@@ -45,7 +45,7 @@ export = {
           ],
           timeout: {
             idle: cdk.Duration.seconds(10),
-            perRequest: cdk.Duration.seconds(10),
+            perRequest: cdk.Duration.seconds(11),
           },
         }),
       });
@@ -75,7 +75,7 @@ export = {
           },
           timeout: {
             idle: cdk.Duration.seconds(10),
-            perRequest: cdk.Duration.seconds(10),
+            perRequest: cdk.Duration.seconds(11),
           },
         }),
       });
@@ -99,6 +99,16 @@ export = {
             },
             Match: {
               Prefix: '/',
+            },
+            Timeout: {
+              Idle: {
+                Value: 10000,
+                Unit: 'ms',
+              },
+              PerRequest: {
+                Value: 11000,
+                Unit: 'ms',
+              },
             },
           },
         },
@@ -124,6 +134,16 @@ export = {
             Match: {
               Prefix: '/',
             },
+            Timeout: {
+              Idle: {
+                Value: 10000,
+                Unit: 'ms',
+              },
+              PerRequest: {
+                Value: 11000,
+                Unit: 'ms',
+              },
+            },
           },
         },
         RouteName: 'test-http2-route',
@@ -144,6 +164,12 @@ export = {
                   Weight: 1,
                 },
               ],
+            },
+            Timeout: {
+              Idle: {
+                Value: 10000,
+                Unit: 'ms',
+              },
             },
           },
         },
@@ -168,6 +194,16 @@ export = {
             },
             Match: {
               ServiceName: 'test.svc.local',
+            },
+            Timeout: {
+              Idle: {
+                Value: 10000,
+                Unit: 'ms',
+              },
+              PerRequest: {
+                Value: 11000,
+                Unit: 'ms',
+              },
             },
           },
         },

--- a/packages/@aws-cdk/aws-appmesh/test/test.virtual-router.ts
+++ b/packages/@aws-cdk/aws-appmesh/test/test.virtual-router.ts
@@ -123,6 +123,10 @@ export = {
           match: {
             prefixPath: '/',
           },
+          timeout: {
+            idle: cdk.Duration.seconds(8),
+            perRequest: cdk.Duration.seconds(8),
+          },
         }),
       });
 
@@ -216,6 +220,10 @@ export = {
           match: {
             prefixPath: '/',
           },
+          timeout: {
+            idle: cdk.Duration.seconds(9),
+            perRequest: cdk.Duration.seconds(9),
+          },
         }),
       });
 
@@ -230,6 +238,10 @@ export = {
           match: {
             prefixPath: '/path2',
           },
+          timeout: {
+            idle: cdk.Duration.seconds(10),
+            perRequest: cdk.Duration.seconds(10),
+          },
         }),
       });
 
@@ -243,6 +255,10 @@ export = {
           ],
           match: {
             prefixPath: '/path3',
+          },
+          timeout: {
+            idle: cdk.Duration.seconds(11),
+            perRequest: cdk.Duration.seconds(11),
           },
         }),
       });
@@ -353,6 +369,9 @@ export = {
               weight: 50,
             },
           ],
+          timeout: {
+            idle: cdk.Duration.seconds(10),
+          },
         }),
       });
 


### PR DESCRIPTION
Add support to http/http2/grpc/tpc route timeouts. 

Reference links for [HttpTimeout](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-httptimeout.html), [GrpcTimeout](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-grpctimeout.html), and [TcpTimeout](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-appmesh-route-tcptimeout.html). (Http2 uses the HttpTimeout object).

closes https://github.com/aws/aws-cdk/issues/11643

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
